### PR TITLE
Remove stray comma in tsconfig.json

### DIFF
--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -9,7 +9,7 @@
         "rootDir": "src",
         "esModuleInterop": true,
         "declaration": true,
-        "sourceMap": true,
+        "sourceMap": true
     },
     "include": [
         "src/",


### PR DESCRIPTION
There's a stray comma in the `sdk/tsconfig.json` file that's causing the Snyk vuln check to fail when importing the project - this *should* fix it.