### PR TITLE
[CAS-137] Fix port null oracle

### DIFF
--- a/programs/castle-lending-aggregator/src/errors.rs
+++ b/programs/castle-lending-aggregator/src/errors.rs
@@ -37,4 +37,7 @@ pub enum ErrorCode {
 
     #[msg("Account passed in is not valid")]
     InvalidAccount,
+
+    #[msg("Insufficient number of accounts for a given operation")]
+    InsufficientAccounts,
 }

--- a/sdk/src/castle_lending_aggregator.ts
+++ b/sdk/src/castle_lending_aggregator.ts
@@ -415,11 +415,6 @@ export type CastleLendingAggregator = {
                     isSigner: false;
                 },
                 {
-                    name: "portOracle";
-                    isMut: false;
-                    isSigner: false;
-                },
-                {
                     name: "jetProgram";
                     isMut: false;
                     isSigner: false;
@@ -1062,6 +1057,11 @@ export type CastleLendingAggregator = {
             code: 310;
             name: "DepositCapError";
             msg: "Vault size limit is reached";
+        },
+        {
+            code: 311;
+            name: "InvalidAccount";
+            msg: "Account passed in is not valid";
         }
     ];
 };
@@ -1480,11 +1480,6 @@ export const IDL: CastleLendingAggregator = {
                 {
                     name: "portReserve",
                     isMut: true,
-                    isSigner: false,
-                },
-                {
-                    name: "portOracle",
-                    isMut: false,
                     isSigner: false,
                 },
                 {
@@ -2130,6 +2125,11 @@ export const IDL: CastleLendingAggregator = {
             code: 310,
             name: "DepositCapError",
             msg: "Vault size limit is reached",
+        },
+        {
+            code: 311,
+            name: "InvalidAccount",
+            msg: "Account passed in is not valid",
         },
     ],
 };

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -228,6 +228,28 @@ export class VaultClient {
     }
 
     private getRefreshIx(): TransactionInstruction {
+        let remainingAccounts = [
+            {
+                isSigner: false,
+                isWritable: true,
+                pubkey: this.vaultState.fees.feeReceiver,
+            },
+            {
+                isSigner: false,
+                isWritable: true,
+                pubkey: this.vaultState.fees.referralFeeReceiver,
+            },
+        ];
+
+        const portOracle = this.port.accounts.oracle;
+        if (portOracle != null) {
+            remainingAccounts.unshift({
+                isSigner: false,
+                isWritable: false,
+                pubkey: portOracle,
+            });
+        }
+
         return this.program.instruction.refresh({
             accounts: {
                 vault: this.vaultId,
@@ -243,7 +265,6 @@ export class VaultClient {
                 solendSwitchboard: this.solend.accounts.switchboardFeed,
                 portProgram: this.port.accounts.program,
                 portReserve: this.port.accounts.reserve,
-                portOracle: this.port.accounts.oracle,
                 jetProgram: this.jet.accounts.program,
                 jetMarket: this.jet.accounts.market,
                 jetMarketAuthority: this.jet.accounts.marketAuthority,
@@ -254,18 +275,7 @@ export class VaultClient {
                 tokenProgram: TOKEN_PROGRAM_ID,
                 clock: SYSVAR_CLOCK_PUBKEY,
             },
-            remainingAccounts: [
-                {
-                    isSigner: false,
-                    isWritable: true,
-                    pubkey: this.vaultState.fees.feeReceiver,
-                },
-                {
-                    isSigner: false,
-                    isWritable: true,
-                    pubkey: this.vaultState.fees.referralFeeReceiver,
-                },
-            ],
+            remainingAccounts: remainingAccounts,
         });
     }
 


### PR DESCRIPTION
# Description

Port does not use an oracle for their USDC lending reserves. They implemented this by having it be optionally passed in via `ctx.remaining_accounts`. It will fail if an oracle is passed in. See here: https://github.com/port-finance/variable-rate-lending/blob/master/token-lending/program/src/processor.rs#L469

Previously, we would always pass in an oracle. This PR fixes that by moving the account to `ctx.remaining_accounts` and amending the client to accommodate that change.

Because we are already using `ctx.remaining_accounts` to take in the optional fee receiver accounts, we need to implement some "hacky" logic to disambiguate them. See the comments above the code in question.

Normally I would want to take the time to build out a "real" solution for this, but this instruction is likely to be refactored anyway and this change is NOT on the security hotpath.

## Type of change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Chore (non-breaking enhancement/refinement)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update
