### PR TITLE
[CAS-86] Add upgrade-ability to on-chain state accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,6 +650,7 @@ dependencies = [
  "static_assertions",
  "strum",
  "strum_macros",
+ "type-layout",
 ]
 
 [[package]]
@@ -783,7 +784,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e1c54951450cbd39f3dbcf1005ac413b49487dabf18a720ad2383eccfeffb92"
 dependencies = [
- "memoffset",
+ "memoffset 0.6.5",
  "rustc_version 0.3.3",
 ]
 
@@ -1028,6 +1029,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b70ca2a6103ac8b665dc150b142ef0e4e89df640c9e6cf295d189c3caebe5a"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1779,6 +1789,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "type-layout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074069282ba5be5078f1bdb34112b963516d50f262bf4c1082fee1f6ada11d74"
+dependencies = [
+ "memoffset 0.5.6",
+ "type-layout-derive",
+]
+
+[[package]]
+name = "type-layout-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4a1cf66ce820973c4b31c5ef47a8e930a53ffbcec191212c33f5a3ad75c6cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,11 +641,13 @@ dependencies = [
  "boolinator",
  "jet",
  "jet-proto-math",
+ "jet-proto-proc-macros",
  "port-anchor-adaptor",
  "port-variable-rate-lending-instructions",
  "solana-maths",
  "spl-math",
  "spl-token-lending",
+ "static_assertions",
  "strum",
  "strum_macros",
 ]
@@ -928,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "jet-proto-proc-macros"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192cd13ebb6b5c319970e5883045441c0334afc21b9c64bc8885f60916310f2"
+checksum = "7eab4c6fd9509fa9c5e6f329363fe47aa77343a5d0b2f82db5a5a2c1e7e3ef6d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "castle-lending-aggregator"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anchor-lang 0.18.2",
  "anchor-spl 0.18.2",

--- a/programs/castle-lending-aggregator/Cargo.toml
+++ b/programs/castle-lending-aggregator/Cargo.toml
@@ -31,10 +31,12 @@ anchor-spl = "0.18.2"
 boolinator = "2.4.0"
 jet = {git = "https://github.com/jet-lab/jet-v1/", version = "0.2.0", features = ["no-entrypoint", "cpi"]}
 jet-proto-math = "1.0.1"
+jet-proto-proc-macros = "1.0.3"
 port-anchor-adaptor = {git = "https://github.com/castle-finance/port-anchor-adaptor.git", version = "0.3.5"}
 port-variable-rate-lending-instructions = "0.2.9"
 solana-maths = "0.1.1"
 spl-math = {version = "0.1", features = ["no-entrypoint"]}
 spl-token-lending = {git = "https://github.com/castle-finance/solana-program-library", version = "0.1.1", features = ["no-entrypoint"]}
+static_assertions = "1.1.0"
 strum = "0.24.0"
 strum_macros = "0.24.0"

--- a/programs/castle-lending-aggregator/Cargo.toml
+++ b/programs/castle-lending-aggregator/Cargo.toml
@@ -2,7 +2,7 @@
 description = "Created with Anchor"
 edition = "2018"
 name = "castle-lending-aggregator"
-version = "1.5.0"
+version = "1.6.0"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/castle-lending-aggregator/Cargo.toml
+++ b/programs/castle-lending-aggregator/Cargo.toml
@@ -40,3 +40,4 @@ spl-token-lending = {git = "https://github.com/castle-finance/solana-program-lib
 static_assertions = "1.1.0"
 strum = "0.24.0"
 strum_macros = "0.24.0"
+type-layout = "0.2.0"

--- a/programs/castle-lending-aggregator/src/instructions/init.rs
+++ b/programs/castle-lending-aggregator/src/instructions/init.rs
@@ -244,6 +244,7 @@ pub fn handler(
         fee_carry_bps: fees.fee_carry_bps,
         fee_mgmt_bps: fees.fee_mgmt_bps,
         referral_fee_pct: fees.referral_fee_pct,
+        _padding: 0_u32,
     };
 
     // Initialize fee receiver account

--- a/programs/castle-lending-aggregator/src/instructions/init.rs
+++ b/programs/castle-lending-aggregator/src/instructions/init.rs
@@ -219,6 +219,7 @@ pub fn handler(
     validate_fees(&fees)?;
 
     let vault = &mut ctx.accounts.vault;
+    vault.version = 0;
     vault.vault_authority = ctx.accounts.vault_authority.key();
     vault.owner = ctx.accounts.owner.key();
     vault.authority_seed = vault.key();

--- a/programs/castle-lending-aggregator/src/instructions/init.rs
+++ b/programs/castle-lending-aggregator/src/instructions/init.rs
@@ -239,14 +239,13 @@ pub fn handler(
     vault.rebalance_mode = rebalance_mode;
     vault.deposit_cap = vault_deposit_cap;
 
-    vault.fees = VaultFees {
-        fee_receiver: ctx.accounts.fee_receiver.key(),
-        referral_fee_receiver: ctx.accounts.referral_fee_receiver.key(),
-        fee_carry_bps: fees.fee_carry_bps,
-        fee_mgmt_bps: fees.fee_mgmt_bps,
-        referral_fee_pct: fees.referral_fee_pct,
-        _padding: 0_u32,
-    };
+    vault.fees = VaultFees::new(
+        fees.fee_carry_bps,
+        fees.fee_mgmt_bps,
+        fees.referral_fee_pct,
+        ctx.accounts.fee_receiver.key(),
+        ctx.accounts.referral_fee_receiver.key(),
+    );
 
     // Initialize fee receiver account
     associated_token::create(ctx.accounts.init_fee_receiver_create_context(

--- a/programs/castle-lending-aggregator/src/state.rs
+++ b/programs/castle-lending-aggregator/src/state.rs
@@ -139,10 +139,18 @@ impl Vault {
     }
 }
 
+#[repr(u8)]
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug)]
 pub enum RebalanceMode {
     Calculator,
     ProofChecker,
+}
+
+#[repr(u8)]
+#[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug)]
+pub enum StrategyType {
+    MaxYield,
+    EqualAllocation,
 }
 
 #[assert_size(aligns, 80)]
@@ -184,12 +192,6 @@ impl VaultFees {
             _padding: [0_u8; 7],
         }
     }
-}
-
-#[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug)]
-pub enum StrategyType {
-    MaxYield,
-    EqualAllocation,
 }
 
 #[assert_size(aligns, 72)]

--- a/programs/castle-lending-aggregator/src/state.rs
+++ b/programs/castle-lending-aggregator/src/state.rs
@@ -22,6 +22,8 @@ pub const ONE_AS_BPS: u64 = 10000;
 #[account]
 #[derive(Debug)]
 pub struct Vault {
+    pub version: u8,
+
     /// Account which is allowed to call restricted instructions
     /// Also the authority of the fee receiver account
     pub owner: Pubkey,
@@ -77,8 +79,10 @@ pub struct Vault {
     /// Whether to run rebalance as a proof check or a calculation
     pub rebalance_mode: RebalanceMode,
 
+    _reserved0: [u8; 15],
+
     // 16 * 12 = 192
-    _reserved: [u128; 12],
+    _reserved1: [u128; 11],
 }
 
 impl Vault {

--- a/programs/castle-lending-aggregator/src/state.rs
+++ b/programs/castle-lending-aggregator/src/state.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::clock::{
     DEFAULT_TICKS_PER_SECOND, DEFAULT_TICKS_PER_SLOT, SECONDS_PER_DAY,
 };
+use jet_proto_proc_macros::assert_size;
 use solana_maths::{Decimal, TryMul};
 use std::cmp::Ordering;
 use strum::IntoEnumIterator;
@@ -17,6 +18,7 @@ pub const SLOTS_PER_YEAR: u64 =
 
 pub const ONE_AS_BPS: u64 = 10000;
 
+#[assert_size(768)]
 #[account]
 #[derive(Debug)]
 pub struct Vault {
@@ -74,6 +76,9 @@ pub struct Vault {
 
     /// Whether to run rebalance as a proof check or a calculation
     pub rebalance_mode: RebalanceMode,
+
+    // 16 * 12 = 192
+    _reserved: [u128; 12],
 }
 
 impl Vault {
@@ -127,6 +132,7 @@ pub enum RebalanceMode {
     ProofChecker,
 }
 
+#[assert_size(aligns, 80)]
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug)]
 pub struct VaultFees {
     /// Basis points of the accrued interest that gets sent to the fee_receiver
@@ -143,6 +149,8 @@ pub struct VaultFees {
 
     /// Account that referral fees from this vault are sent to
     pub referral_fee_receiver: Pubkey,
+
+    pub _padding: u32,
 }
 
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug)]
@@ -151,6 +159,7 @@ pub enum StrategyType {
     EqualAllocation,
 }
 
+#[assert_size(aligns, 72)]
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug, Default)]
 pub struct Allocations {
     pub solend: Allocation,
@@ -176,6 +185,7 @@ impl Allocations {
     }
 }
 
+#[assert_size(aligns, 24)]
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug, Default)]
 pub struct Allocation {
     pub value: u64,
@@ -197,6 +207,7 @@ impl Allocation {
 /// Number of slots to consider stale after
 pub const STALE_AFTER_SLOTS_ELAPSED: u64 = 2;
 
+#[assert_size(aligns, 16)]
 #[derive(AnchorDeserialize, AnchorSerialize, Clone, Copy, Debug, Default)]
 pub struct LastUpdate {
     pub slot: u64,

--- a/scripts/create_vault.ts
+++ b/scripts/create_vault.ts
@@ -3,33 +3,34 @@ import { Program, Provider, Wallet } from "@project-serum/anchor";
 import { NATIVE_MINT } from "@solana/spl-token";
 
 import {
-    CastleLendingAggregator,
+    DeploymentEnvs,
+    RebalanceModes,
+    StrategyTypes,
+} from "@castlefinance/vault-core";
+
+import {
     JetReserveAsset,
     PortReserveAsset,
-    PROGRAM_ID,
     SolendReserveAsset,
     VaultClient,
 } from "../sdk/src";
 
 const main = async () => {
-    const cluster: Cluster = "mainnet-beta";
+    //const cluster: Cluster = "mainnet-beta";
+    const cluster: Cluster = "devnet";
     const connection = new Connection(
-        "https://solana-api.syndica.io/access-token/PBhwkfVgRLe1MEpLI5VbMDcfzXThjLKDHroc31shR5e7qrPqQi9TAUoV6aD3t0pg/rpc"
+        //"https://solana-api.syndica.io/access-token/PBhwkfVgRLe1MEpLI5VbMDcfzXThjLKDHroc31shR5e7qrPqQi9TAUoV6aD3t0pg/rpc"
+        "https://psytrbhymqlkfrhudd.dev.genesysgo.net:8899/"
     );
     const wallet = Wallet.local();
     const provider = new Provider(connection, wallet, {
         commitment: "confirmed",
     });
-    const program = (await Program.at(
-        //PROGRAM_ID,
-        new PublicKey("Cast1eoVj8hwfKKRPji4cqX7WFgcnYz3um7TTgnaJKFn"),
-        provider
-    )) as Program<CastleLendingAggregator>;
 
-    //const reserveMint = NATIVE_MINT;
-    const reserveMint = new PublicKey(
-        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
-    );
+    const reserveMint = NATIVE_MINT;
+    //const reserveMint = new PublicKey(
+    //    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    //);
 
     const solend = await SolendReserveAsset.load(
         provider,
@@ -40,14 +41,15 @@ const main = async () => {
     const jet = await JetReserveAsset.load(provider, cluster, reserveMint);
 
     const vaultClient = await VaultClient.initialize(
-        program,
+        provider,
         wallet,
+        DeploymentEnvs.devnetStaging,
         reserveMint,
         solend,
         port,
         jet,
-        { maxYield: {} },
-        { calculator: {} },
+        StrategyTypes.maxYield,
+        RebalanceModes.calculator,
         wallet.publicKey,
         {
             feeCarryBps: 0,

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@castlefinance/vault-sdk",
-    "version": "1.5.9",
+    "version": "1.6.0",
     "license": "MIT",
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@castlefinance/vault-sdk",
-    "version": "1.5.8",
+    "version": "1.5.9",
     "license": "MIT",
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",

--- a/sdk/src/castle_lending_aggregator.ts
+++ b/sdk/src/castle_lending_aggregator.ts
@@ -692,6 +692,10 @@ export type CastleLendingAggregator = {
                 kind: "struct";
                 fields: [
                     {
+                        name: "version";
+                        type: "u8";
+                    },
+                    {
                         name: "owner";
                         type: "publicKey";
                     },
@@ -746,6 +750,22 @@ export type CastleLendingAggregator = {
                         type: "publicKey";
                     },
                     {
+                        name: "rebalanceMode";
+                        type: {
+                            defined: "RebalanceMode";
+                        };
+                    },
+                    {
+                        name: "strategyType";
+                        type: {
+                            defined: "StrategyType";
+                        };
+                    },
+                    {
+                        name: "padding0";
+                        type: "u32";
+                    },
+                    {
                         name: "fees";
                         type: {
                             defined: "VaultFees";
@@ -772,20 +792,20 @@ export type CastleLendingAggregator = {
                         };
                     },
                     {
-                        name: "strategyType";
-                        type: {
-                            defined: "StrategyType";
-                        };
-                    },
-                    {
-                        name: "rebalanceMode";
-                        type: {
-                            defined: "RebalanceMode";
-                        };
-                    },
-                    {
                         name: "allocationCapPct";
                         type: "u8";
+                    },
+                    {
+                        name: "padding1";
+                        type: {
+                            array: ["u8", 7];
+                        };
+                    },
+                    {
+                        name: "reserved";
+                        type: {
+                            array: ["u64", 23];
+                        };
                     }
                 ];
             };
@@ -888,6 +908,12 @@ export type CastleLendingAggregator = {
                     {
                         name: "referralFeeReceiver";
                         type: "publicKey";
+                    },
+                    {
+                        name: "padding";
+                        type: {
+                            array: ["u8", 7];
+                        };
                     }
                 ];
             };
@@ -948,6 +974,12 @@ export type CastleLendingAggregator = {
                     {
                         name: "stale";
                         type: "bool";
+                    },
+                    {
+                        name: "padding";
+                        type: {
+                            array: ["u8", 7];
+                        };
                     }
                 ];
             };
@@ -1788,6 +1820,10 @@ export const IDL: CastleLendingAggregator = {
                 kind: "struct",
                 fields: [
                     {
+                        name: "version",
+                        type: "u8",
+                    },
+                    {
                         name: "owner",
                         type: "publicKey",
                     },
@@ -1842,6 +1878,22 @@ export const IDL: CastleLendingAggregator = {
                         type: "publicKey",
                     },
                     {
+                        name: "rebalanceMode",
+                        type: {
+                            defined: "RebalanceMode",
+                        },
+                    },
+                    {
+                        name: "strategyType",
+                        type: {
+                            defined: "StrategyType",
+                        },
+                    },
+                    {
+                        name: "padding0",
+                        type: "u32",
+                    },
+                    {
                         name: "fees",
                         type: {
                             defined: "VaultFees",
@@ -1868,20 +1920,20 @@ export const IDL: CastleLendingAggregator = {
                         },
                     },
                     {
-                        name: "strategyType",
-                        type: {
-                            defined: "StrategyType",
-                        },
-                    },
-                    {
-                        name: "rebalanceMode",
-                        type: {
-                            defined: "RebalanceMode",
-                        },
-                    },
-                    {
                         name: "allocationCapPct",
                         type: "u8",
+                    },
+                    {
+                        name: "padding1",
+                        type: {
+                            array: ["u8", 7],
+                        },
+                    },
+                    {
+                        name: "reserved",
+                        type: {
+                            array: ["u64", 23],
+                        },
                     },
                 ],
             },
@@ -1985,6 +2037,12 @@ export const IDL: CastleLendingAggregator = {
                         name: "referralFeeReceiver",
                         type: "publicKey",
                     },
+                    {
+                        name: "padding",
+                        type: {
+                            array: ["u8", 7],
+                        },
+                    },
                 ],
             },
         },
@@ -2044,6 +2102,12 @@ export const IDL: CastleLendingAggregator = {
                     {
                         name: "stale",
                         type: "bool",
+                    },
+                    {
+                        name: "padding",
+                        type: {
+                            array: ["u8", 7],
+                        },
                     },
                 ],
             },

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -90,8 +90,9 @@ export class VaultClient {
     }
 
     static async initialize(
-        program: anchor.Program<CastleLendingAggregator>,
+        provider: anchor.Provider,
         wallet: anchor.Wallet,
+        env: DeploymentEnv,
         reserveTokenMint: PublicKey,
         solend: SolendReserveAsset,
         port: PortReserveAsset,
@@ -100,8 +101,19 @@ export class VaultClient {
         rebalanceMode: RebalanceMode,
         owner: PublicKey,
         feeData: FeeArgs,
-        poolSizeLimit: number = 10000000000
+        poolSizeLimit: number = 10000000000,
+        program?: anchor.Program<CastleLendingAggregator>
     ): Promise<VaultClient> {
+        // TODO Once the below issue is resolved, remove this logic
+        // https://github.com/project-serum/anchor/issues/1844
+        // Program should only be passed in during testing
+        if (program == null) {
+            program = (await anchor.Program.at(
+                PROGRAM_IDS[env],
+                provider
+            )) as anchor.Program<CastleLendingAggregator>;
+        }
+
         const { feeCarryBps, feeMgmtBps, referralFeeOwner, referralFeePct } =
             feeData;
 

--- a/tests/castle-lending-aggregator.ts
+++ b/tests/castle-lending-aggregator.ts
@@ -12,6 +12,7 @@ import {
     ProposedWeightsBps,
 } from "../sdk/src/index";
 import {
+    DeploymentEnvs,
     RebalanceMode,
     RebalanceModes,
     StrategyType,
@@ -233,8 +234,9 @@ describe("castle-vault", () => {
         referralFeePct: number = 0
     ) {
         vaultClient = await VaultClient.initialize(
-            program,
+            provider,
             provider.wallet as anchor.Wallet,
+            DeploymentEnvs.devnetStaging,
             reserveToken.publicKey,
             solend,
             port,
@@ -243,7 +245,8 @@ describe("castle-vault", () => {
             rebalanceMode,
             owner.publicKey,
             { feeCarryBps, feeMgmtBps, referralFeeOwner, referralFeePct },
-            vaultDepositCap
+            vaultDepositCap,
+            program
         );
 
         userReserveTokenAccount = await reserveToken.createAccount(


### PR DESCRIPTION
This PR adds deterministic type layouts and extra reserved space to the on-chains state account `Vault`. This enables us to add extra data into the account in future program upgrades. All padding in structs is done explicitly so as to not hide implementation details that could trip us up later on. We use Jet's `assert_size` proc macro to ensure that structs are the sizes we expect them to be.

Tested by deploying to devnet-staging, creating vault, uptaking allocation_cap changes, and ensuring we can grab the new data.
Create: 5JQiUDYxNKM444f14shJY5R5yYjUahZiutknJY7mjqFPdPZ6G5iFbXGyMvvQPhpfS7UbNfgKR1sqLE9AP1mPTNzs

Enhancements:
* Modify `initialize` in sdk to use `DeploymentEnv` type to match `load`

References:
https://doc.rust-lang.org/reference/type-layout.html
https://doc.rust-lang.org/nomicon/repr-rust.html

Current Vault layout:
```
Vault (size 768, alignment 8)
| Offset | Name                  | Size |
| ------ | --------------------- | ---- |
| 0      | version               | 1    |
| 1      | owner                 | 32   |
| 33     | vault_authority       | 32   |
| 65     | authority_seed        | 32   |
| 97     | authority_bump        | 1    |
| 98     | solend_reserve        | 32   |
| 130    | port_reserve          | 32   |
| 162    | jet_reserve           | 32   |
| 194    | vault_reserve_token   | 32   |
| 226    | vault_solend_lp_token | 32   |
| 258    | vault_port_lp_token   | 32   |
| 290    | vault_jet_lp_token    | 32   |
| 322    | lp_token_mint         | 32   |
| 354    | reserve_token_mint    | 32   |
| 386    | rebalance_mode        | 1    |
| 387    | strategy_type         | 1    |
| 388    | allocation_cap_pct    | 1    |
| 389    | _padding0             | 3    |
| 392    | fees                  | 80   |
| 472    | last_update           | 16   |
| 488    | total_value           | 8    |
| 496    | deposit_cap           | 8    |
| 504    | allocations           | 72   |
| 576    | _reserved             | 192  |
```