### PR TITLE
[CAS-346] Fix LP token supply bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,7 +634,7 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "castle-vault"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anchor-lang 0.18.2",
  "anchor-spl 0.18.2",

--- a/programs/castle-vault/Cargo.toml
+++ b/programs/castle-vault/Cargo.toml
@@ -6,7 +6,7 @@ homepage = "https://castle.finance"
 license = "GPL-3.0-or-later"
 name = "castle-vault"
 repository = "https://github.com/castle-finance/castle-vault/"
-version = "3.2.0"
+version = "3.2.1"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/programs/castle-vault/src/instructions/consolidate_refresh.rs
+++ b/programs/castle-vault/src/instructions/consolidate_refresh.rs
@@ -7,10 +7,12 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::{self, Mint, MintTo, Token, TokenAccount};
 use port_anchor_adaptor::{port_lending_id, PortReserve};
 
-use crate::adapters::{solend, SolendReserve};
-use crate::errors::ErrorCode;
-use crate::reserves::Provider;
-use crate::state::{Vault, VaultFlags};
+use crate::{
+    adapters::{solend, SolendReserve},
+    errors::ErrorCode,
+    reserves::Provider,
+    state::{SlotTrackedValue, Vault, VaultFlags},
+};
 use strum::IntoEnumIterator;
 
 #[derive(Accounts)]
@@ -82,8 +84,8 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ConsolidateRefresh<'info>>
 
     // Calculate new vault value
     let vault_reserve_token_amount = ctx.accounts.vault_reserve_token.amount;
-    let vault_value = Provider::iter().try_fold(vault_reserve_token_amount, |acc, p| {
-        let allocation = ctx.accounts.vault.actual_allocations[p];
+    let vault_value = Provider::iter().try_fold(vault_reserve_token_amount, |acc: u64, p| {
+        let allocation: SlotTrackedValue = ctx.accounts.vault.actual_allocations[p];
         if ctx.accounts.vault.get_yield_source_availability(p) {
             // We skip pools where we have zero allocation
             // Must do it inside the if block because we have to check yield source flags first
@@ -221,6 +223,15 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ConsolidateRefresh<'info>>
                 .with_signer(&[&vault.authority_seeds()]),
             referral_fees_converted,
         )?;
+
+        // increment token supply
+        ctx.accounts.vault.lp_token_supply = ctx
+            .accounts
+            .vault
+            .lp_token_supply
+            .checked_add(primary_fees_converted)
+            .and_then(|val| val.checked_add(primary_fees_converted))
+            .ok_or(ErrorCode::MathError)?;
     }
 
     // Update vault total value

--- a/programs/castle-vault/src/instructions/consolidate_refresh.rs
+++ b/programs/castle-vault/src/instructions/consolidate_refresh.rs
@@ -230,7 +230,7 @@ pub fn handler<'info>(ctx: Context<'_, '_, '_, 'info, ConsolidateRefresh<'info>>
             .vault
             .lp_token_supply
             .checked_add(primary_fees_converted)
-            .and_then(|val| val.checked_add(primary_fees_converted))
+            .and_then(|val| val.checked_add(referral_fees_converted))
             .ok_or(ErrorCode::MathError)?;
     }
 

--- a/programs/castle-vault/src/instructions/deposit.rs
+++ b/programs/castle-vault/src/instructions/deposit.rs
@@ -103,9 +103,10 @@ pub fn handler(ctx: Context<Deposit>, reserve_token_amount: u64) -> ProgramResul
 
     let vault = &ctx.accounts.vault;
 
+    // Use vault token supply
     let lp_tokens_to_mint = crate::math::calc_reserve_to_lp(
         reserve_token_amount,
-        ctx.accounts.lp_token_mint.supply,
+        ctx.accounts.vault.lp_token_supply,
         vault.value.value,
     )
     .ok_or(ErrorCode::MathError)?;
@@ -134,6 +135,13 @@ pub fn handler(ctx: Context<Deposit>, reserve_token_amount: u64) -> ProgramResul
             .with_signer(&[&vault.authority_seeds()]),
         lp_tokens_to_mint,
     )?;
+
+    ctx.accounts.vault.lp_token_supply = ctx
+        .accounts
+        .vault
+        .lp_token_supply
+        .checked_add(lp_tokens_to_mint)
+        .ok_or(ErrorCode::MathError)?;
 
     // This is so that the SDK can read an up-to-date total value without calling refresh
     ctx.accounts.vault.value.value = ctx

--- a/programs/castle-vault/src/instructions/init_vault.rs
+++ b/programs/castle-vault/src/instructions/init_vault.rs
@@ -157,6 +157,7 @@ pub fn handler(
         last_update: LastUpdate::new(clock.slot),
     };
     vault.config = VaultConfig::new(config)?;
+    vault.lp_token_supply = 0;
 
     // Initialize fee receiver account
     associated_token::create(ctx.accounts.init_fee_receiver_create_context(

--- a/programs/castle-vault/src/state.rs
+++ b/programs/castle-vault/src/state.rs
@@ -80,9 +80,11 @@ pub struct Vault {
     // Actual allocation retrieved by refresh
     pub actual_allocations: Allocations,
 
-    // 8 * 23 = 184
+    pub lp_token_supply: u64,
+
+    // 4 * 26 = 104
     /// Reserved space for future upgrades
-    _reserved: [u32; 28],
+    _reserved: [u32; 26],
 }
 
 impl Vault {
@@ -348,7 +350,7 @@ impl SlotTrackedValue {
 }
 
 /// Number of slots to consider stale after
-pub const STALE_AFTER_SLOTS_ELAPSED: u64 = 2;
+pub const STALE_AFTER_SLOTS_ELAPSED: u64 = 1;
 
 #[assert_size(aligns, 16)]
 #[repr(C, align(8))]

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@castlefinance/vault-sdk",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "license": "MIT",
     "main": "./lib/index.js",
     "typings": "./lib/index.d.ts",

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -1017,10 +1017,10 @@ export class VaultClient {
 
     // Denominated in reserve tokens per LP token
     async getLpExchangeRate(): Promise<ExchangeRate> {
+        await this.reload();
+
         const totalValue = (await this.getTotalValue()).lamports;
-        const lpTokenSupply = new Big(
-            (await this.getLpTokenMintInfo()).supply.toString()
-        );
+        const lpTokenSupply = new Big(this.vaultState.lpTokenSupply.toString());
 
         const bigZero = new Big(0);
         if (lpTokenSupply.eq(bigZero) || totalValue.eq(bigZero)) {
@@ -1167,6 +1167,10 @@ export class VaultClient {
             Keypair.generate() // dummy since we don't need to send txs
         );
         return lpToken.getMintInfo();
+    }
+
+    getVaultLpTokenSupply(): anchor.BN {
+        return this.vaultState.lpTokenSupply;
     }
 
     getVaultConfig(): VaultConfig {

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -1169,8 +1169,17 @@ export class VaultClient {
         return lpToken.getMintInfo();
     }
 
-    getVaultLpTokenSupply(): anchor.BN {
-        return this.vaultState.lpTokenSupply;
+    // This should only be used for tests
+    getVaultState(): Vault {
+        return this.vaultState;
+    }
+
+    async getVaultLpTokenSupply(): Promise<TokenAmount> {
+        await this.reload();
+        return TokenAmount.fromToken(
+            this.lpToken,
+            Big(this.vaultState.lpTokenSupply.toString())
+        );
     }
 
     getVaultConfig(): VaultConfig {

--- a/sdk/src/idl.ts
+++ b/sdk/src/idl.ts
@@ -984,9 +984,13 @@ export type CastleVault = {
                         };
                     },
                     {
+                        name: "lpTokenSupply";
+                        type: "u64";
+                    },
+                    {
                         name: "reserved";
                         type: {
-                            array: ["u32", 28];
+                            array: ["u32", 26];
                         };
                     }
                 ];
@@ -2357,9 +2361,13 @@ export const IDL: CastleVault = {
                         },
                     },
                     {
+                        name: "lpTokenSupply",
+                        type: "u64",
+                    },
+                    {
                         name: "reserved",
                         type: {
-                            array: ["u32", 28],
+                            array: ["u32", 26],
                         },
                     },
                 ],

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -30,6 +30,7 @@ export interface Vault {
     targetAllocations: Allocations;
     config: VaultConfig;
     actualAllocations: Allocations;
+    lpTokenSupply: BN;
 }
 
 export interface VaultConfig {

--- a/sdk/test/client.test.ts
+++ b/sdk/test/client.test.ts
@@ -37,12 +37,13 @@ describe("VaultClient", () => {
 
     it("loads devnet sol vault", async () => {
         const vaultId = new PublicKey(
-            //"Bv4d2wWb7myxpjWudHnEMjdJstxjkiWqX61xLhPBrBx" //devnet-staging
+            //"7MXreZLSP1Xm9EiLvEf2gZKsQqeuyUHuL54vVSyvFfZi" //devnet-staging
             "3tBqjyYtf9Utb1NNsx4o7AV1qtzHoxsMXgkmat3rZ3y6" //mainnet
         );
         vaultClient = await VaultClient.load(
             provider,
             vaultId,
+            //DeploymentEnvs.devnetStaging
             DeploymentEnvs.mainnet
         );
         assert.isNotNull(vaultClient);
@@ -86,77 +87,77 @@ describe("VaultClient", () => {
         console.log((await port.getDepositedAmount()).getAmount());
     });
 
-    it("deposits", async () => {
-        const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
-        console.log("start value: ", startUserValue.getAmount());
+    //it("deposits", async () => {
+    //    const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
+    //    console.log("start value: ", startUserValue.getAmount());
 
-        //const userReserveTokenAccount = wallet.publicKey;
-        const userReserveTokenAccount =
-            await vaultClient.getUserReserveTokenAccount(wallet.publicKey);
-        try {
-            const sigs = await vaultClient.deposit(
-                wallet,
-                depositAmount.lamports.toNumber(),
-                userReserveTokenAccount
-            );
-            await connection.confirmTransaction(
-                sigs[sigs.length - 1],
-                "finalized"
-            );
-        } catch (e) {
-            console.log(e);
-            throw e;
-        }
+    //    //const userReserveTokenAccount = wallet.publicKey;
+    //    const userReserveTokenAccount =
+    //        await vaultClient.getUserReserveTokenAccount(wallet.publicKey);
+    //    try {
+    //        const sigs = await vaultClient.deposit(
+    //            wallet,
+    //            depositAmount.lamports.toNumber(),
+    //            userReserveTokenAccount
+    //        );
+    //        await connection.confirmTransaction(
+    //            sigs[sigs.length - 1],
+    //            "finalized"
+    //        );
+    //    } catch (e) {
+    //        console.log(e);
+    //        throw e;
+    //    }
 
-        const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
-        console.log("end value: ", endUserValue.getAmount());
+    //    const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
+    //    console.log("end value: ", endUserValue.getAmount());
 
-        assert.isAtMost(
-            Math.abs(
-                endUserValue.sub(startUserValue).sub(depositAmount).getAmount()
-            ),
-            1000
-        );
-    });
+    //    assert.isAtMost(
+    //        Math.abs(
+    //            endUserValue.sub(startUserValue).sub(depositAmount).getAmount()
+    //        ),
+    //        1000
+    //    );
+    //});
 
-    it("rebalances", async () => {
-        const sigs = await vaultClient.rebalance();
-        const result = await connection.confirmTransaction(
-            sigs[sigs.length - 1],
-            "finalized"
-        );
-        assert.isNull(result.value.err);
-    });
+    //it("rebalances", async () => {
+    //    const sigs = await vaultClient.rebalance();
+    //    const result = await connection.confirmTransaction(
+    //        sigs[sigs.length - 1],
+    //        "finalized"
+    //    );
+    //    assert.isNull(result.value.err);
+    //});
 
-    it("withdraws", async () => {
-        const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
-        console.log("start value: ", startUserValue.getAmount());
+    //it("withdraws", async () => {
+    //    const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
+    //    console.log("start value: ", startUserValue.getAmount());
 
-        const exchangeRate = await vaultClient.getLpExchangeRate();
-        const withdrawAmount = depositAmount.lamports
-            .div(exchangeRate.toBig())
-            .round(0, Big.roundDown)
-            .toNumber();
+    //    const exchangeRate = await vaultClient.getLpExchangeRate();
+    //    const withdrawAmount = depositAmount.lamports
+    //        .div(exchangeRate.toBig())
+    //        .round(0, Big.roundDown)
+    //        .toNumber();
 
-        try {
-            const sigs = await vaultClient.withdraw(wallet, withdrawAmount);
-            await connection.confirmTransaction(
-                sigs[sigs.length - 1],
-                "finalized"
-            );
-        } catch (e) {
-            console.log(e);
-            throw e;
-        }
+    //    try {
+    //        const sigs = await vaultClient.withdraw(wallet, withdrawAmount);
+    //        await connection.confirmTransaction(
+    //            sigs[sigs.length - 1],
+    //            "finalized"
+    //        );
+    //    } catch (e) {
+    //        console.log(e);
+    //        throw e;
+    //    }
 
-        const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
-        console.log("end value: ", endUserValue.getAmount());
+    //    const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
+    //    console.log("end value: ", endUserValue.getAmount());
 
-        assert.isAtMost(
-            Math.abs(
-                startUserValue.sub(endUserValue).sub(depositAmount).getAmount()
-            ),
-            1000
-        );
-    });
+    //    assert.isAtMost(
+    //        Math.abs(
+    //            startUserValue.sub(endUserValue).sub(depositAmount).getAmount()
+    //        ),
+    //        1000
+    //    );
+    //});
 });

--- a/sdk/test/client.test.ts
+++ b/sdk/test/client.test.ts
@@ -87,77 +87,77 @@ describe("VaultClient", () => {
         console.log((await port.getDepositedAmount()).getAmount());
     });
 
-    //it("deposits", async () => {
-    //    const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
-    //    console.log("start value: ", startUserValue.getAmount());
+    it("deposits", async () => {
+        const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
+        console.log("start value: ", startUserValue.getAmount());
 
-    //    //const userReserveTokenAccount = wallet.publicKey;
-    //    const userReserveTokenAccount =
-    //        await vaultClient.getUserReserveTokenAccount(wallet.publicKey);
-    //    try {
-    //        const sigs = await vaultClient.deposit(
-    //            wallet,
-    //            depositAmount.lamports.toNumber(),
-    //            userReserveTokenAccount
-    //        );
-    //        await connection.confirmTransaction(
-    //            sigs[sigs.length - 1],
-    //            "finalized"
-    //        );
-    //    } catch (e) {
-    //        console.log(e);
-    //        throw e;
-    //    }
+        //const userReserveTokenAccount = wallet.publicKey;
+        const userReserveTokenAccount =
+            await vaultClient.getUserReserveTokenAccount(wallet.publicKey);
+        try {
+            const sigs = await vaultClient.deposit(
+                wallet,
+                depositAmount.lamports.toNumber(),
+                userReserveTokenAccount
+            );
+            await connection.confirmTransaction(
+                sigs[sigs.length - 1],
+                "finalized"
+            );
+        } catch (e) {
+            console.log(e);
+            throw e;
+        }
 
-    //    const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
-    //    console.log("end value: ", endUserValue.getAmount());
+        const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
+        console.log("end value: ", endUserValue.getAmount());
 
-    //    assert.isAtMost(
-    //        Math.abs(
-    //            endUserValue.sub(startUserValue).sub(depositAmount).getAmount()
-    //        ),
-    //        1000
-    //    );
-    //});
+        assert.isAtMost(
+            Math.abs(
+                endUserValue.sub(startUserValue).sub(depositAmount).getAmount()
+            ),
+            1000
+        );
+    });
 
-    //it("rebalances", async () => {
-    //    const sigs = await vaultClient.rebalance();
-    //    const result = await connection.confirmTransaction(
-    //        sigs[sigs.length - 1],
-    //        "finalized"
-    //    );
-    //    assert.isNull(result.value.err);
-    //});
+    it("rebalances", async () => {
+        const sigs = await vaultClient.rebalance();
+        const result = await connection.confirmTransaction(
+            sigs[sigs.length - 1],
+            "finalized"
+        );
+        assert.isNull(result.value.err);
+    });
 
-    //it("withdraws", async () => {
-    //    const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
-    //    console.log("start value: ", startUserValue.getAmount());
+    it("withdraws", async () => {
+        const startUserValue = await vaultClient.getUserValue(wallet.publicKey);
+        console.log("start value: ", startUserValue.getAmount());
 
-    //    const exchangeRate = await vaultClient.getLpExchangeRate();
-    //    const withdrawAmount = depositAmount.lamports
-    //        .div(exchangeRate.toBig())
-    //        .round(0, Big.roundDown)
-    //        .toNumber();
+        const exchangeRate = await vaultClient.getLpExchangeRate();
+        const withdrawAmount = depositAmount.lamports
+            .div(exchangeRate.toBig())
+            .round(0, Big.roundDown)
+            .toNumber();
 
-    //    try {
-    //        const sigs = await vaultClient.withdraw(wallet, withdrawAmount);
-    //        await connection.confirmTransaction(
-    //            sigs[sigs.length - 1],
-    //            "finalized"
-    //        );
-    //    } catch (e) {
-    //        console.log(e);
-    //        throw e;
-    //    }
+        try {
+            const sigs = await vaultClient.withdraw(wallet, withdrawAmount);
+            await connection.confirmTransaction(
+                sigs[sigs.length - 1],
+                "finalized"
+            );
+        } catch (e) {
+            console.log(e);
+            throw e;
+        }
 
-    //    const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
-    //    console.log("end value: ", endUserValue.getAmount());
+        const endUserValue = await vaultClient.getUserValue(wallet.publicKey);
+        console.log("end value: ", endUserValue.getAmount());
 
-    //    assert.isAtMost(
-    //        Math.abs(
-    //            startUserValue.sub(endUserValue).sub(depositAmount).getAmount()
-    //        ),
-    //        1000
-    //    );
-    //});
+        assert.isAtMost(
+            Math.abs(
+                startUserValue.sub(endUserValue).sub(depositAmount).getAmount()
+            ),
+            1000
+        );
+    });
 });

--- a/tests/castle-vault.ts
+++ b/tests/castle-vault.ts
@@ -293,8 +293,8 @@ describe("castle-vault", () => {
     }
 
     async function getLpTokenSupply(): Promise<number> {
-        const info = await vaultClient.getLpTokenMintInfo();
-        return info.supply.toNumber();
+        await vaultClient.reload();
+        return vaultClient.getVaultState().lpTokenSupply.toNumber();
     }
 
     async function mintReserveToken(receiver: PublicKey, qty: number) {

--- a/tests/castle-vault.ts
+++ b/tests/castle-vault.ts
@@ -344,7 +344,7 @@ describe("castle-vault", () => {
             const preRefresh = vaultClient.getPreRefreshTxs().map((tx) => {
                 return { tx: tx, signers: [] };
             });
-            const txs: SendTxRequest[] = [
+            const txs = [
                 ...preRefresh,
                 {
                     tx: await vaultClient.getRebalanceTx(proposedWeights),


### PR DESCRIPTION
Message from osec Robert
```
A. the supply in calc_reserve_to_lp is manipulatable by burning tokens. there's an attack scenario if you can be the first to deposit. consider the following scenario,

1. deposit(1000 * 10^6 USD tokens) -> receive 1000 * 10^6 castle tokens back
2. burn 1000 * 10^6 - 1 castle tokens, supply is 1
3. any user who deposits less than 1000 USD will have their deposit amount rounded down, giving the money to the first user for free

alternatively they could burn all their tokens, locking all future deposits. 
```

This PR fixes this issue by introducing a new variable in the `Vault` state account `lp_token_supply`, which is kept up-to-date and referenced during lp token conversion calculations.